### PR TITLE
Only include debug info when -DCMAKE_BUILD_TYPE=Debug

### DIFF
--- a/Src/CMakeLists.txt
+++ b/Src/CMakeLists.txt
@@ -5,8 +5,8 @@ project(libCZI)
 IF(UNIX)
 # linking with 'thread' is necessary if we use std::thread and related under Linux it seems
 #   otherwise - the program simply crashes (no build-error)
-   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -pthread -std=c++11 -fPIC -D_FILE_OFFSET_BITS=64")
-   SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -D__ANSI__ -fPIC -D_FILE_OFFSET_BITS=64")
+   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -std=c++11 -fPIC -D_FILE_OFFSET_BITS=64")
+   SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__ANSI__ -fPIC -D_FILE_OFFSET_BITS=64")
 ENDIF(UNIX)
 
 add_subdirectory(JxrDecode)


### PR DESCRIPTION
The default CMake system already adds `-g` when the build type is Debug. This changes removes it from the default compiler flags so that symbol information isn't included when the build type is Release.