### PR TITLE
Add method CreateStreamFromMemory to get stream in-memory

### DIFF
--- a/Src/libCZI/StreamImpl.cpp
+++ b/Src/libCZI/StreamImpl.cpp
@@ -26,6 +26,7 @@
 #include <sstream>
 #include <codecvt>
 #include <iomanip>
+#include <cstring>
 
 using namespace std;
 
@@ -161,3 +162,22 @@ void CSimpleStreamImplWindows::Read(std::uint64_t offset, void *pv, std::uint64_
 	}
 }
 #endif
+
+CSimpleStreamImplInMemory::CSimpleStreamImplInMemory(const void * const ptr)
+{
+	_ptr = ptr;
+}
+
+CSimpleStreamImplInMemory::~CSimpleStreamImplInMemory()
+{
+}
+
+void CSimpleStreamImplInMemory::Read(std::uint64_t offset, void *pv, std::uint64_t size, std::uint64_t* ptrBytesRead)
+{
+	void* offsetPtr = (void*)((char*)_ptr + offset);
+	std::memcpy(pv, offsetPtr, size);
+	if (ptrBytesRead != nullptr)
+	{
+		*ptrBytesRead = size;
+	}
+}

--- a/Src/libCZI/StreamImpl.h
+++ b/Src/libCZI/StreamImpl.h
@@ -64,3 +64,16 @@ public:	// interface libCZI::IStream
 	virtual void Read(std::uint64_t offset, void *pv, std::uint64_t size, std::uint64_t* ptrBytesRead);
 };
 #endif
+
+/// <summary>	A simplistic stream implementation (based on in-memory copy). Note that this implementation is NOT thread-safe.</summary>
+class CSimpleStreamImplInMemory : public libCZI::IStream
+{
+private:
+	const void* _ptr;
+public:
+	CSimpleStreamImplInMemory() = delete;
+	CSimpleStreamImplInMemory(const void * const ptr);
+	~CSimpleStreamImplInMemory();
+public:	// interface libCZI::IStream
+	virtual void Read(std::uint64_t offset, void *pv, std::uint64_t size, std::uint64_t* ptrBytesRead);
+};

--- a/Src/libCZI/StreamImpl.h
+++ b/Src/libCZI/StreamImpl.h
@@ -69,10 +69,12 @@ public:	// interface libCZI::IStream
 class CSimpleStreamImplInMemory : public libCZI::IStream
 {
 private:
-	const void* _ptr;
+	std::shared_ptr<const void> rawData;
+	std::uint64_t dataBufferSize;
 public:
 	CSimpleStreamImplInMemory() = delete;
-	CSimpleStreamImplInMemory(const void * const ptr);
+	CSimpleStreamImplInMemory(std::shared_ptr<const void> ptr, std::uint64_t dataSize);
+	CSimpleStreamImplInMemory(std::shared_ptr<libCZI::IAttachment> attachement);
 	~CSimpleStreamImplInMemory();
 public:	// interface libCZI::IStream
 	virtual void Read(std::uint64_t offset, void *pv, std::uint64_t size, std::uint64_t* ptrBytesRead);

--- a/Src/libCZI/libCZI.h
+++ b/Src/libCZI/libCZI.h
@@ -108,6 +108,10 @@ namespace libCZI
 	/// \return The new stream object.
 	LIBCZI_API std::shared_ptr<IStream> CreateStreamFromFile(const wchar_t* szFilename);
 
+	/// Creates a stream-object for another stream in memory.
+	/// \param ptr	Pointer to another stream
+	/// \return			The new stream object.
+	LIBCZI_API std::shared_ptr<IStream> CreateStreamFromMemory(const void * const ptr);
 
 	/// Interface used for accessing the data-stream.
 	///

--- a/Src/libCZI/libCZI.h
+++ b/Src/libCZI/libCZI.h
@@ -75,6 +75,7 @@ namespace libCZI
 	class ISubBlock;
 	class IMetadataSegment;
 	class ISubBlockRepository;
+	class IAttachment;
 
 	/// Gets the version of the library.
 	///
@@ -111,7 +112,11 @@ namespace libCZI
 	/// Creates a stream-object for another stream in memory.
 	/// \param ptr	Pointer to another stream
 	/// \return			The new stream object.
-	LIBCZI_API std::shared_ptr<IStream> CreateStreamFromMemory(const void * const ptr);
+	LIBCZI_API std::shared_ptr<IStream> CreateStreamFromMemory(std::shared_ptr<const void> ptr, std::uint64_t dataSize);
+	/// Creates a stream-object from IAttachment
+	/// \param attachement	Pointer to attachement
+	/// \return			The new stream object.
+	LIBCZI_API std::shared_ptr<IStream> CreateStreamFromMemory(std::shared_ptr<IAttachment> attachement);
 
 	/// Interface used for accessing the data-stream.
 	///

--- a/Src/libCZI/libCZI_Lib.cpp
+++ b/Src/libCZI/libCZI_Lib.cpp
@@ -78,3 +78,8 @@ std::shared_ptr<IStream> libCZI::CreateStreamFromFile(const wchar_t* szFilename)
 	return make_shared<CSimpleStreamImpl>(szFilename);
 #endif
 }
+
+std::shared_ptr<IStream> libCZI::CreateStreamFromMemory(const void * const ptr)
+{
+	return make_shared<CSimpleStreamImplInMemory>(ptr);
+}

--- a/Src/libCZI/libCZI_Lib.cpp
+++ b/Src/libCZI/libCZI_Lib.cpp
@@ -78,8 +78,11 @@ std::shared_ptr<IStream> libCZI::CreateStreamFromFile(const wchar_t* szFilename)
 	return make_shared<CSimpleStreamImpl>(szFilename);
 #endif
 }
-
-std::shared_ptr<IStream> libCZI::CreateStreamFromMemory(const void * const ptr)
+std::shared_ptr<IStream> libCZI::CreateStreamFromMemory(std::shared_ptr<const void> ptr, std::uint64_t dataSize)
 {
-	return make_shared<CSimpleStreamImplInMemory>(ptr);
+	return make_shared<CSimpleStreamImplInMemory>(ptr, dataSize);
+}
+std::shared_ptr<IStream> libCZI::CreateStreamFromMemory(std::shared_ptr<libCZI::IAttachment> attachement)
+{
+	return make_shared<CSimpleStreamImplInMemory>(attachement);
 }


### PR DESCRIPTION
Hello, 

I have an use case that I need to read attachment in-memory. There seem no other ways to read the attached images without saving it to file first. So I implemented this function `CreateStreamFromMemory` to copy the stream directly. The usage is the following.
```
std::shared_ptr<libCZI::IStream> cziStream_ = libCZI::CreateStreamFromFile(L"CZI.czi");
std::shared_ptr<libCZI::ICZIReader> reader_ = libCZI::CreateCZIReader();
reader_->Open(cziStream_);
std::shared_ptr<libCZI::ICZIReader> labelReader = libCZI::CreateCZIReader();
std::shared_ptr<libCZI::IStream> strm;
reader_->EnumerateAttachments(
	[&](int index, const libCZI::AttachmentInfo& info)->bool
{
	auto attchmnt = reader_->ReadAttachment(index);
	if (!attchmnt)
	{
		return false;
	}
	if (info.name == "Label")
	{
		size_t size;
		std::shared_ptr<const void> spData = attchmnt->GetRawData(&size);
		// Create reader stream in memory
		strm = libCZI::CreateStreamFromMemory(spData.get());
		labelReader->Open(strm);
		auto tileAccessor = labelReader->CreateSingleChannelTileAccessor();
	}
}
```