### PR TITLE
Add CMake install commands

### DIFF
--- a/Src/CMakeLists.txt
+++ b/Src/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 2.8)
 
-project(libCZI)
+# allow version specification in call to project()
+cmake_policy(SET CMP0048 NEW)
+
+project(libCZI VERSION 0.0.0)
 
 IF(UNIX)
 # linking with 'thread' is necessary if we use std::thread and related under Linux it seems

--- a/Src/CZICmd/CMakeLists.txt
+++ b/Src/CZICmd/CMakeLists.txt
@@ -12,4 +12,9 @@ target_link_libraries(CZIcmd ${PNG_LIBRARIES} ${ZLIB_LIBRARIES})
 include_directories(${ZLIB_INCLUDE_DIR} ${PNG_INCLUDE_DIR})
 ENDIF(UNIX)
 
+install(TARGETS CZIcmd
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)
+
 

--- a/Src/CZICmd/CMakeLists.txt
+++ b/Src/CZICmd/CMakeLists.txt
@@ -1,16 +1,36 @@
-IF(UNIX)
-find_package(ZLIB)
-find_package(PNG)
-ENDIF(UNIX)
+IF (UNIX)
+    find_package(ZLIB)
+    find_package(PNG)
+ENDIF (UNIX)
 
-add_executable(CZIcmd cmdlineoptions.cpp consoleio.cpp execute.cpp getOpt.cpp CZIcmd.cpp SaveBitmap.cpp stdafx.cpp streamimpl.cpp cmdlineoptions.h consoleio.h execute.h getOpt.h inc_libCZI.h SaveBitmap.h stdafx.h streamimpl.h targetver.h utils.cpp utils.h platform_defines.h DisplaySettingsHelper.h)
+add_executable(CZIcmd
+        cmdlineoptions.cpp
+        consoleio.cpp
+        execute.cpp
+        getOpt.cpp
+        CZIcmd.cpp
+        SaveBitmap.cpp
+        stdafx.cpp
+        streamimpl.cpp
+        cmdlineoptions.h
+        consoleio.h
+        execute.h
+        getOpt.h
+        inc_libCZI.h
+        SaveBitmap.h
+        stdafx.h
+        streamimpl.h
+        targetver.h
+        utils.cpp
+        utils.h
+        platform_defines.h
+        DisplaySettingsHelper.h)
 
 add_definitions(-DUNICODE -D_UNICODE)
 target_link_libraries(CZIcmd PRIVATE libCZI)
-IF(UNIX)
-target_link_libraries(CZIcmd ${PNG_LIBRARIES} ${ZLIB_LIBRARIES})
-include_directories(${ZLIB_INCLUDE_DIR} ${PNG_INCLUDE_DIR})
-ENDIF(UNIX)
+IF (UNIX)
+    target_link_libraries(CZIcmd PRIVATE PNG::PNG ZLIB::ZLIB)
+ENDIF (UNIX)
 
 install(TARGETS CZIcmd
         RUNTIME DESTINATION bin

--- a/Src/libCZI/CMakeLists.txt
+++ b/Src/libCZI/CMakeLists.txt
@@ -1,14 +1,105 @@
+set(LIBCZI_PUBLIC_HDRS
+        ImportExport.h
+        libCZI_Compositor.h
+        libCZI_DimCoordinate.h
+        libCZI_exceptions.h
+        libCZI_Helpers.h
+        libCZI_Metadata.h
+        libCZI_Pixels.h
+        libCZI_Site.h
+        libCZI_Utilities.h
+        libCZI.h)
 
-file(GLOB LIBCZISRCFILES "*.h" "*.cpp" "*.hpp")
-file(GLOB_RECURSE LIBCZISRCEIGENFILES "eigen/*")
-#add_library(NaCZIrLib SHARED CreateBitmap.cpp CziDimensionInfo.cpp CziMetadata.cpp CziMetadataDocumentInfo.cpp CziMetadataSegment.cpp CziParse.cpp CZIReader.cpp CziSubBlock.cpp CziSubBlockDirectory.cpp CziUtils.cpp decoder.cpp DimCoordinate.cpp dllmain.cpp MultiChannelTileCompositor.cpp NaCZIrLib.cpp NaCZIr_Utilities.cpp SingleChannelTileAccessor.cpp SingleChannelTileCompositor.cpp stdafx.cpp stdAllocator.cpp bitmapData.h CreateBitmap.h CziDataStructs.h CziDimensionInfo.h CziMetadata.h CziMetadataDocumentInfo.h CziMetadataSegment.h CziParse.h CZIReader.h CziStructs.h CziSubBlock.h CziSubBlockDirectory.h CziUtils.h datastore.h decoder.h DimCoordinate.h DimensionIndexExtended.h ImportExport.h MultiChannelTileCompositor.h NaCZIr.h NaCZIr_Compositor.h NaCZIr_DimCoordinate.h NaCZIr_Metadata.h NaCZIr_Pixels.h NaCZIr_Utilities.h readerwriterlocker.h SingleChannelTileAccessor.h SingleChannelTileCompositor.h stdafx.h stdAllocator.h targetver.h utilities.cpp utilities.h pugiconfig.hpp pugixml.cpp pugiconfig.hpp CziDisplaySettings.h CziDisplaySettings.cpp NaCZIr_Site.h NaCZIr_Site.cpp BitmapOperations.cpp BitmapOperations.h MD5Sum.cpp MD5Sum.h splines.h splines.cpp Site.h priv_guiddef.h NaCZIr_exceptions.h SingleChannelPyramidLevelTileAccessor.cpp SingleChannelPyramidLevelTileAccessor.h SingleChannelAccessorBase.cpp SingleChannelAccessorBase.h SingleChannelScalingTileAccessor.cpp SingleChannelScalingTileAccessor.h StreamImpl.cpp StreamImpl.h)
+set(LIBCZI_SRCS
+        bitmapData.h
+        BitmapOperations.cpp
+        BitmapOperations.h
+        BitmapOperations.hpp
+        CreateBitmap.cpp
+        CziAttachment.cpp
+        CziAttachment.h
+        CziAttachmentsDirectory.cpp
+        CziAttachmentsDirectory.h
+        CziDataStructs.h
+        CziDimensionInfo.cpp
+        CziDimensionInfo.h
+        CziDisplaySettings.cpp
+        CziDisplaySettings.h
+        CziMetadata.cpp
+        CziMetadata.h
+        CziMetadataDocumentInfo.cpp
+        CziMetadataDocumentInfo.h
+        CziMetadataSegment.cpp
+        CziMetadataSegment.h
+        CziParse.cpp
+        CziParse.h
+        CZIReader.cpp
+        CZIReader.h
+        CziStructs.h
+        CziSubBlock.cpp
+        CziSubBlock.h
+        CziSubBlockDirectory.cpp
+        CziSubBlockDirectory.h
+        CziUtils.cpp
+        CziUtils.h
+        decoder.cpp
+        decoder.h
+        decoder_wic.cpp
+        decoder_wic.h
+        DimCoordinate.cpp
+        dllmain.cpp
+        IndexSet.cpp
+        IndexSet.h
+        libCZI_Lib.cpp
+        libCZI_Site.cpp
+        libCZI_Utilities.cpp
+        MD5Sum.cpp
+        MD5Sum.h
+        MultiChannelCompositor.cpp
+        MultiChannelCompositor.h
+        priv_guiddef.h
+        pugiconfig.hpp
+        pugixml.cpp
+        pugixml.hpp
+        SingleChannelAccessorBase.cpp
+        SingleChannelAccessorBase.h
+        SingleChannelPyramidLevelTileAccessor.cpp
+        SingleChannelPyramidLevelTileAccessor.h
+        SingleChannelScalingTileAccessor.cpp
+        SingleChannelScalingTileAccessor.h
+        SingleChannelTileAccessor.cpp
+        SingleChannelTileAccessor.h
+        SingleChannelTileCompositor.cpp
+        SingleChannelTileCompositor.h
+        Site.h
+        splines.cpp
+        splines.h
+        stdafx.cpp
+        stdafx.h
+        stdAllocator.cpp
+        stdAllocator.h
+        StreamImpl.cpp
+        StreamImpl.h
+        targetver.h
+        utilities.cpp
+        utilities.h)
 
-add_library(libCZI SHARED ${LIBCZISRCFILES} ${LIBCZISRCEIGENFILES})
+file(GLOB_RECURSE LIBCZI_EIGEN_HDRS "eigen/*")
 
-SET_TARGET_PROPERTIES (libCZI PROPERTIES DEFINE_SYMBOL  "LIBCZI_EXPORTS" )
+add_library(libCZI SHARED ${LIBCZI_PUBLIC_HDRS} ${LIBCZI_SRCS} ${LIBCZI_EIGEN_HDRS})
+
+set_target_properties(libCZI PROPERTIES DEFINE_SYMBOL "LIBCZI_EXPORTS")
+set_target_properties(libCZI PROPERTIES PUBLIC_HEADER "${LIBCZI_PUBLIC_HDRS}")
 
 target_link_libraries (libCZI PRIVATE JxrDecodeStatic)
 
-add_library(libCZIStatic STATIC ${LIBCZISRCFILES} ${LIBCZISRCEIGENFILES})
+add_library(libCZIStatic STATIC ${LIBCZI_PUBLIC_HDRS} ${LIBCZI_SRCS} ${LIBCZI_EIGEN_HDRS})
 
-SET_TARGET_PROPERTIES (libCZIStatic PROPERTIES DEFINE_SYMBOL  "LIBCZI_EXPORTS" )
+set_target_properties(libCZIStatic PROPERTIES DEFINE_SYMBOL "LIBCZI_EXPORTS")
+set_target_properties(libCZIStatic PROPERTIES PUBLIC_HEADER "${LIBCZI_PUBLIC_HDRS}")
+
+install(TARGETS libCZI libCZIStatic
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        PUBLIC_HEADER DESTINATION include)

--- a/Src/libCZI/CMakeLists.txt
+++ b/Src/libCZI/CMakeLists.txt
@@ -87,6 +87,10 @@ set(LIBCZI_SRCS
 file(GLOB_RECURSE LIBCZI_EIGEN_HDRS "eigen/*")
 
 add_library(libCZI SHARED ${LIBCZI_PUBLIC_HDRS} ${LIBCZI_SRCS} ${LIBCZI_EIGEN_HDRS})
+target_include_directories(libCZI
+                           PUBLIC
+                           $<INSTALL_INTERFACE:include/libCZI>
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 set_target_properties(libCZI PROPERTIES DEFINE_SYMBOL "LIBCZI_EXPORTS")
 set_target_properties(libCZI PROPERTIES PUBLIC_HEADER "${LIBCZI_PUBLIC_HDRS}")
@@ -94,6 +98,10 @@ set_target_properties(libCZI PROPERTIES PUBLIC_HEADER "${LIBCZI_PUBLIC_HDRS}")
 target_link_libraries (libCZI PRIVATE JxrDecodeStatic)
 
 add_library(libCZIStatic STATIC ${LIBCZI_PUBLIC_HDRS} ${LIBCZI_SRCS} ${LIBCZI_EIGEN_HDRS})
+target_include_directories(libCZIStatic
+                           PUBLIC
+                           $<INSTALL_INTERFACE:include/libCZI>
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 set_target_properties(libCZIStatic PROPERTIES DEFINE_SYMBOL "LIBCZI_EXPORTS")
 set_target_properties(libCZIStatic PROPERTIES PUBLIC_HEADER "${LIBCZI_PUBLIC_HDRS}")
@@ -102,4 +110,4 @@ install(TARGETS libCZI libCZIStatic
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib
-        PUBLIC_HEADER DESTINATION include)
+        PUBLIC_HEADER DESTINATION include/libCZI)

--- a/Src/libCZI/CMakeLists.txt
+++ b/Src/libCZI/CMakeLists.txt
@@ -92,7 +92,7 @@ target_include_directories(libCZI
                            $<INSTALL_INTERFACE:include/libCZI>
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
-set_target_properties(libCZI PROPERTIES DEFINE_SYMBOL "LIBCZI_EXPORTS")
+target_compile_definitions(libCZI PRIVATE "LIBCZI_EXPORTS")
 set_target_properties(libCZI PROPERTIES PUBLIC_HEADER "${LIBCZI_PUBLIC_HDRS}")
 
 target_link_libraries (libCZI PRIVATE JxrDecodeStatic)
@@ -103,8 +103,10 @@ target_include_directories(libCZIStatic
                            $<INSTALL_INTERFACE:include/libCZI>
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
-set_target_properties(libCZIStatic PROPERTIES DEFINE_SYMBOL "LIBCZI_EXPORTS")
+target_compile_definitions(libCZIStatic PUBLIC "LIBCZI_EXPORTS")
 set_target_properties(libCZIStatic PROPERTIES PUBLIC_HEADER "${LIBCZI_PUBLIC_HDRS}")
+
+target_link_libraries (libCZIStatic PRIVATE JxrDecodeStatic)
 
 install(TARGETS libCZI libCZIStatic
         RUNTIME DESTINATION bin

--- a/Src/libCZI/CziSubBlockDirectory.cpp
+++ b/Src/libCZI/CziSubBlockDirectory.cpp
@@ -134,8 +134,6 @@ void CCziSubBlockDirectory::UpdateStatistics(const SubBlkEntry& entry)
 			}
 		}
 
-		++this->statistics.subBlockCount;
-
 		return true;
 	});
 
@@ -198,6 +196,8 @@ void CCziSubBlockDirectory::UpdateStatistics(const SubBlkEntry& entry)
 		this->UpdatePyramidLayerStatistics(vecPs, pli);
 		this->pyramidStatistics.scenePyramidStatistics.insert(std::pair<int, std::vector<PyramidStatistics::PyramidLayerStatistics>>(sceneIndex, vecPs));
 	}
+
+	this->statistics.subBlockCount = this->subBlks.size();
 
 }
 

--- a/Src/libCZI/SingleChannelPyramidLevelTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelPyramidLevelTileAccessor.cpp
@@ -1,23 +1,23 @@
 //******************************************************************************
-// 
+//
 // libCZI is a reader for the CZI fileformat written in C++
 // Copyright (C) 2017  Zeiss Microscopy GmbH
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 // To obtain a commercial version please contact Zeiss Microscopy GmbH.
-// 
+//
 //******************************************************************************
 
 #include "stdafx.h"
@@ -83,7 +83,12 @@ void CSingleChannelPyramidLevelTileAccessor::InternalGet(libCZI::IBitmapData* pD
 
 	auto byLayer = CalcByLayer(subSet, pyramidInfo.minificationFactor);
 	// ok, now we just have to look at our requested pyramid-layer
-	const auto& indices = byLayer.at(pyramidInfo.pyramidLayerNo).indices;
+	const auto itr = byLayer.find(pyramidInfo.pyramidLayerNo);
+	if (itr == byLayer.end()) {
+		return;
+	}
+
+	const auto& indices = itr->second.indices;
 
 	// and now... copy...
 	this->ComposeTiles(pDest, xPos, yPos, sizeOfPixelOnLayer0, (int)indices.size(), options,


### PR DESCRIPTION
This pull request adds CMake `install()` directives for the libCZI, libCZIStatic, and CZIcmd targets. This allows you to run `make install` on Unix systems or generates an INSTALL project for Visual Studio. It will put the libraries and public headers wherever `CMAKE_INSTALL_PREFIX` points.

I had to split out the libCZI sources to access the public headers so they can be installed with the library. It might be desirable to add another directory level for the installed includes to keep them isolated.