### PR TITLE
Uncompressed subblocks workaround

### DIFF
--- a/Src/CZICmd/cmdlineoptions.cpp
+++ b/Src/CZICmd/cmdlineoptions.cpp
@@ -267,20 +267,28 @@ void CCmdLineOptions::PrintUsage(int switchesCnt, std::function<std::tuple<std::
 			L"COMMAND",
 			LR"(COMMAND can be any of 'PrintInformation', 'ExtractSubBlock', 'SingleChannelTileAccessor', 'ChannelComposite', 
                 'SingleChannelPyramidTileAccessor', 'SingleChannelScalingTileAccessor', 'ScalingChannelComposite' and 'ExtractAttachment'. 
+				\n-
 				\n'PrintInformation' will print information about the CZI-file to the console. The argument 'info-level' can be used
 				to specify which information is to be printed. 
+				\n-
                 \n'ExtractSubBlock' will write the bitmap contained in the specified sub-block to the OUTPUTFILE. 
+				\n-
 				\n'ChannelComposite' will create a 
 				channel-composite of the specified region and plane and apply display-settings to it. The resulting bitmap will be written
 				to the specified OUTPUTFILE. 
+				\n-
 				\n'SingleChannelTileAccessor' will create a tile-composite (only from sub-blocks on pyramid-layer 0) of the specified region and plane.
                 The resulting bitmap will be written to the specified OUTPUTFILE. 
+				\n-
 				\n'SingleChannelPyramidTileAccessor' adds to the previous command the ability to explictely address a specific pyramid-layer (which must
 				exist in the CZI-document). 
+				\n-
 				\n'SingleChannelScalingTileAccessor' gets the specified region with an arbitrary zoom factor. It uses the pyramid-layers in the CZI-document
 				and scales the bitmap if neccessary. The resulting bitmap will be written to the specified OUTPUTFILE. 
+				\n-
 				\n'ScalingChannelComposite' operates like the previous command, but in addition gets all channels and creates a multi-channel-composite from them
                 using display-settings.
+				\n-
 				\n'ExtractAttachment' allows to extract (and save to a file) the contents of attachments.)"
 		},
 		{
@@ -319,11 +327,13 @@ void CCmdLineOptions::PrintUsage(int switchesCnt, std::function<std::tuple<std::
 			L"",
 			LR"(Calculate a hash for the output-picture. The MD5Sum-algorithm is used for this.)"
 		},
+#if 0  // Remove this help text, which masks the background color option help text.
 		{
 			L"b",
 			L"",
 			LR"(Draw a one-pixel black line around each tile.)"
 		},
+#endif // Remove this help text, which masks the background color option help text.
 		{
 			L"j",
 			L"DECODERNAME",

--- a/Src/libCZI/SingleChannelPyramidLevelTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelPyramidLevelTileAccessor.cpp
@@ -82,6 +82,11 @@ void CSingleChannelPyramidLevelTileAccessor::InternalGet(libCZI::IBitmapData* pD
 	}
 
 	auto byLayer = CalcByLayer(subSet, pyramidInfo.minificationFactor);
+	if (byLayer.count(pyramidInfo.pyramidLayerNo) == 0)
+	{	// No subblocks were found in the requested pyramid layer, so there is nothing to do.
+		return;
+	}
+
 	// ok, now we just have to look at our requested pyramid-layer
 	const auto& indices = byLayer.at(pyramidInfo.pyramidLayerNo).indices;
 


### PR DESCRIPTION
I have sample *.czi files which ZEN 3.0 (blue edition) was able to render, but CZIcmd failed on (with commands ExtractSubBlock, ChannelComposite, etc.), stopping and printing decompression error messages.

Upon reading hexdumps of these *.czi files (pointed to by lots of added debugging messages), I found that in the sample *.czi files that were failing there were specific SubBlocks which the SubBlock Metadata labeled as JpxXr compressed, but the corresponding binary SubBlock Data did **not** have the correct JpxXr magic header bytes 0x49 0x49 0xbc 0x01.  These SubBlocks -- labeled as JpxXr, but without correct magic header -- were exactly where CZIcmd failed, stopped, and printed a decompression error.

Further examination of these failing SubBlocks found that the binary SubBlock Data size was exactly that of uncompressed pixel data.

WIth the change I made in CreateBitmapFromSubBlock_JpgXr(), I was able to use CZIcmd to render images for these previously failing *.czi files.  The rendered images agreed with ZEN rendering.

Since the CZIcmd code was correctly checking for the JpxXr label and JpxXr magic header (as verified by reading *.czi hexdumps) and finding a conflict, I concluded:
-- the CZIcmd code was actually "correct" in failing with a decompression error,
-- but that ZEN was compensating for the label<>magic header conflict,
-- so ... there were legacy CZI file creators which had a bug and created bad *.czi files; but ZEN was explicitly compensating for this bug, while CZIcmd was not.

The change I have made in CreateBitmapFromSubBlock_JpgXr() is an error compensation that works for all the otherwise failing *.czi files that I have:
-- it checks for the label<>magic header conflict (which would otherwise fail with a decompression error),
-- and checks that the binary SubBlock Data datasize corresponds with uncompressed pixel data,
-- and if both happen, reverts to CreateBitmapFromSubBlock_Uncompressed() to process the SubBlock.

-------------------------------------------------------------------------------------------
Other changes in this pull request:
- pretty print readability change to 'CZIcmd --help' to further separate the '-c COMMAND, --command COMMAND' options in the help text

- expose the 'CZIcmd --help' help text for '-b BACKGROUND, --background BACKGROUND' for specifying a background color for Composite images [I looked into implementing this functionality, and upon tracing through the code found that it already existed, but the help text didn't expose it.  And that there were two '-b' options.  Oops.]