### PR TITLE
aligned_alloc is a C11 function but not defined on all linux distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ There are at least two python wrappers available for libCZI. They provide easy a
 
 #### AICSImageIO
 
-This library from the Allen Cell Institute for Cell Science uses libCZI among other tools to read CZI, OME-TIFF and TIFF images and can be found here: [AICSimageIO](https://allencellmodeling.github.io/aicsimageio/)
+This library from the Allen Institute for Cell Science uses libCZI among other tools to read CZI, OME-TIFF and TIFF images and can be found here: [AICSimageIO](https://allencellmodeling.github.io/aicsimageio/)
 
 #### pylibCZI
 

--- a/Src/libCZI/CziParse.cpp
+++ b/Src/libCZI/CziParse.cpp
@@ -297,7 +297,7 @@ using namespace libCZI;
 	// the reserved size of the "subblock-segment-data" is given by "SIZE_SUBBLOCKDATA_MINIMUM", but the actual size of the
 	//  data-structure (SubBlockDirectoryEntryDV) may be larger than that - so we need to take the max of the actual size and
 	//  the reserved (minimal) size here
-	lengthSubblockSegmentData = max(lengthSubblockSegmentData + SIZE_SUBBLOCKDATA_FIXEDPART, SIZE_SUBBLOCKDATA_MINIMUM);
+	lengthSubblockSegmentData = max(lengthSubblockSegmentData + SIZE_SUBBLOCKDATA_FIXEDPART, (uint32_t)SIZE_SUBBLOCKDATA_MINIMUM);
 
 	// TODO: if subBlckSegment.data.DataSize > size_t (=4GB for 32Bit) then bail out gracefully
 	auto deleter = [&](void* ptr) -> void {allocateInfo.free(ptr); };

--- a/Src/libCZI/SingleChannelScalingTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelScalingTileAccessor.cpp
@@ -81,7 +81,8 @@ CSingleChannelScalingTileAccessor::CSingleChannelScalingTileAccessor(std::shared
 
 /*static*/libCZI::IntSize CSingleChannelScalingTileAccessor::InternalCalcSize(const libCZI::IntRect& roi, float zoom)
 {
-	return IntSize{ (uint32_t)ceil(roi.w*zoom),(uint32_t)ceil(roi.h*zoom) };
+    // return IntSize{ (uint32_t)ceil(roi.w*zoom),(uint32_t)ceil(roi.h*zoom) };
+    return IntSize{ (uint32_t)(roi.w*zoom),(uint32_t)(roi.h*zoom) };
 }
 
 void CSingleChannelScalingTileAccessor::ScaleBlt(libCZI::IBitmapData* bmDest, float zoom, const libCZI::IntRect&  roi, const SbInfo& sbInfo)

--- a/Src/libCZI/SingleChannelScalingTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelScalingTileAccessor.cpp
@@ -82,7 +82,7 @@ CSingleChannelScalingTileAccessor::CSingleChannelScalingTileAccessor(std::shared
 /*static*/libCZI::IntSize CSingleChannelScalingTileAccessor::InternalCalcSize(const libCZI::IntRect& roi, float zoom)
 {
     // return IntSize{ (uint32_t)ceil(roi.w*zoom),(uint32_t)ceil(roi.h*zoom) };
-    return IntSize{ (uint32_t)floor(roi.w*zoom),(uint32_t)floor(roi.h*zoom) };
+    return IntSize{ (uint32_t)ceil(roi.w*zoom),(uint32_t)ceil(roi.h*zoom) };
 }
 
 void CSingleChannelScalingTileAccessor::ScaleBlt(libCZI::IBitmapData* bmDest, float zoom, const libCZI::IntRect&  roi, const SbInfo& sbInfo)

--- a/Src/libCZI/SingleChannelScalingTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelScalingTileAccessor.cpp
@@ -25,7 +25,7 @@
 #include "utilities.h"
 #include "BitmapOperations.h"
 #include "Site.h"
-//#include <math.h>
+#include <cmath>
 
 using namespace libCZI;
 using namespace std;

--- a/Src/libCZI/SingleChannelScalingTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelScalingTileAccessor.cpp
@@ -82,7 +82,7 @@ CSingleChannelScalingTileAccessor::CSingleChannelScalingTileAccessor(std::shared
 /*static*/libCZI::IntSize CSingleChannelScalingTileAccessor::InternalCalcSize(const libCZI::IntRect& roi, float zoom)
 {
     // return IntSize{ (uint32_t)ceil(roi.w*zoom),(uint32_t)ceil(roi.h*zoom) };
-    return IntSize{ (uint32_t)round(roi.w*zoom),(uint32_t)round(roi.h*zoom) };
+    return IntSize{ (uint32_t)floor(roi.w*zoom),(uint32_t)floor(roi.h*zoom) };
 }
 
 void CSingleChannelScalingTileAccessor::ScaleBlt(libCZI::IBitmapData* bmDest, float zoom, const libCZI::IntRect&  roi, const SbInfo& sbInfo)

--- a/Src/libCZI/SingleChannelScalingTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelScalingTileAccessor.cpp
@@ -82,7 +82,7 @@ CSingleChannelScalingTileAccessor::CSingleChannelScalingTileAccessor(std::shared
 /*static*/libCZI::IntSize CSingleChannelScalingTileAccessor::InternalCalcSize(const libCZI::IntRect& roi, float zoom)
 {
     // return IntSize{ (uint32_t)ceil(roi.w*zoom),(uint32_t)ceil(roi.h*zoom) };
-    return IntSize{ (uint32_t)(roi.w*zoom),(uint32_t)(roi.h*zoom) };
+    return IntSize{ (uint32_t)round(roi.w*zoom),(uint32_t)round(roi.h*zoom) };
 }
 
 void CSingleChannelScalingTileAccessor::ScaleBlt(libCZI::IBitmapData* bmDest, float zoom, const libCZI::IntRect&  roi, const SbInfo& sbInfo)

--- a/Src/libCZI/SingleChannelScalingTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelScalingTileAccessor.cpp
@@ -25,7 +25,7 @@
 #include "utilities.h"
 #include "BitmapOperations.h"
 #include "Site.h"
-#include <math.h>
+//#include <math.h>
 
 using namespace libCZI;
 using namespace std;

--- a/Src/libCZI/SingleChannelScalingTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelScalingTileAccessor.cpp
@@ -1,23 +1,23 @@
 //******************************************************************************
-// 
+//
 // libCZI is a reader for the CZI fileformat written in C++
 // Copyright (C) 2017  Zeiss Microscopy GmbH
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 // To obtain a commercial version please contact Zeiss Microscopy GmbH.
-// 
+//
 //******************************************************************************
 
 #include "stdafx.h"
@@ -25,6 +25,7 @@
 #include "utilities.h"
 #include "BitmapOperations.h"
 #include "Site.h"
+#include <cmath>
 
 using namespace libCZI;
 using namespace std;
@@ -80,7 +81,7 @@ CSingleChannelScalingTileAccessor::CSingleChannelScalingTileAccessor(std::shared
 
 /*static*/libCZI::IntSize CSingleChannelScalingTileAccessor::InternalCalcSize(const libCZI::IntRect& roi, float zoom)
 {
-	return IntSize{ (uint32_t)(roi.w*zoom),(uint32_t)(roi.h*zoom) };
+	return IntSize{ (uint32_t)ceil(roi.w*zoom),(uint32_t)ceil(roi.h*zoom) };
 }
 
 void CSingleChannelScalingTileAccessor::ScaleBlt(libCZI::IBitmapData* bmDest, float zoom, const libCZI::IntRect&  roi, const SbInfo& sbInfo)
@@ -138,12 +139,12 @@ int CSingleChannelScalingTileAccessor::GetIdxOf1stSubBlockWithZoomGreater(const 
 	return -1;
 }
 
-/// <summary>	
-/// Create an vector with indices (into the specified vector with SubBlock-infos) so that the indices give 
+/// <summary>
+/// Create an vector with indices (into the specified vector with SubBlock-infos) so that the indices give
 /// the items sorted by their "zoom"-factor. (A zoom of "1" means that the subblock is on layer-0). Subblocks of
 /// a higher pyramid-layer are at the end of the list.
 /// </summary>
-/// <remarks>	
+/// <remarks>
 /// TODO: within a pyramid-layer, the subblocks should be sorted according to their M-index. The problem is (once again...)
 /// to define a "pyramid-layer". Since, currently, only layer-0 may have overlapping tiles, it is only relevant for layer-0,
 /// and layer-0 can be easily defined by physical_size==logical_size.

--- a/Src/libCZI/SingleChannelScalingTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelScalingTileAccessor.cpp
@@ -25,7 +25,6 @@
 #include "utilities.h"
 #include "BitmapOperations.h"
 #include "Site.h"
-#include <cmath>
 
 using namespace libCZI;
 using namespace std;
@@ -81,8 +80,7 @@ CSingleChannelScalingTileAccessor::CSingleChannelScalingTileAccessor(std::shared
 
 /*static*/libCZI::IntSize CSingleChannelScalingTileAccessor::InternalCalcSize(const libCZI::IntRect& roi, float zoom)
 {
-    // return IntSize{ (uint32_t)ceil(roi.w*zoom),(uint32_t)ceil(roi.h*zoom) };
-    return IntSize{ (uint32_t)ceil(roi.w*zoom),(uint32_t)ceil(roi.h*zoom) };
+     return IntSize{ (uint32_t)(roi.w*zoom),(uint32_t)(roi.h*zoom) };
 }
 
 void CSingleChannelScalingTileAccessor::ScaleBlt(libCZI::IBitmapData* bmDest, float zoom, const libCZI::IntRect&  roi, const SbInfo& sbInfo)

--- a/Src/libCZI/SingleChannelScalingTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelScalingTileAccessor.cpp
@@ -25,7 +25,7 @@
 #include "utilities.h"
 #include "BitmapOperations.h"
 #include "Site.h"
-#include <cmath>
+#include <math.h>
 
 using namespace libCZI;
 using namespace std;

--- a/Src/libCZI/stdAllocator.cpp
+++ b/Src/libCZI/stdAllocator.cpp
@@ -30,24 +30,24 @@ void* CHeapAllocator::Allocate(std::uint64_t size)
 	{
 		throw std::out_of_range("The requested size for allocation is out-of-range.");
 	}
-#if defined(__EMSCRIPTEN__)||defined(__APPLE__)
-	return malloc((size_t)size);
-#else
-#if defined(__GNUC__)
+	// Compilation was failing on the original with linux distros that don't have the _ISOC11_SOURCE.
+#if defined(_WIN32)
+	return (void *)_aligned_malloc((size_t)size, 32);
+#elif defined(_ISOC11_SOURCE)
 	return aligned_alloc(32, size);
 #else
-	void* pv = _aligned_malloc((size_t)size, 32);
-	return pv;
-#endif
+	return malloc((size_t)size);
 #endif
 }
 
 void CHeapAllocator::Free(void* ptr)
 {
-#if defined(__GNUC__)||defined(__EMSCRIPTEN__)
-	free(ptr);
+#if defined(_WIN32)
+    _aligned_free(ptr);
+#elif defined(_ISOC11_SOURCE)
+    free(ptr);
 #else
-	_aligned_free(ptr);
+    free(ptr);
 #endif
 }
 


### PR DESCRIPTION
* changed conditional check to query if C11 functions are defined
* fixed name in readme

The initial code assumes that aligned_alloc is defined in C++ but aligned_alloc is part of the C11 and isn't incorporated into C++ until C++17. To the best of my knowledge, the latest version of C++ that libCZI compiles against is C++14 because Eigen has a conflict with C++17. 

What this means:
libCZI compilation fails on Manylinux2010 which I believe is based off Centos 6.

To remedy this issue I've modified the conditional logic to check for _ISOC11_SOURCE.